### PR TITLE
feat: add automatic admin audit logging

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -20,6 +20,7 @@ from .config import get_config
 from .utils.logging_setup import setup_logging, setup_json_logging, with_request_id
 from .utils.error_handlers import register_error_handlers as register_enhanced_error_handlers
 from .utils.cache import init_l1_cache_from_config
+from .utils.audit import bind_auto_audit
 from .realtime import init_realtime
 from .db import db as db
 
@@ -360,6 +361,13 @@ def create_app(config_name: str = None) -> Flask:
 
     # Register blueprints
     register_blueprints(app)
+
+    # Bind automatic admin auditing after blueprint registration so the hooks
+    # observe all admin endpoints.
+    try:
+        bind_auto_audit(app)
+    except Exception:
+        logger.debug("Auto audit hook could not be registered", exc_info=True)
 
     # Create and register versioned API
     api_bp_v1, api = _create_v1_api(app)

--- a/backend/tests/test_audit_logging.py
+++ b/backend/tests/test_audit_logging.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask, g, jsonify, request
+
+from backend.db.models import AuditLog
+from backend.utils.audit import bind_auto_audit, log_action
+
+
+@pytest.fixture
+def audit_app():
+    from backend.db import db as audit_db
+    import backend.db.models  # noqa: F401 - ensure models registered
+    import backend.models.plan  # noqa: F401 - ensure plan table exists
+
+    app = Flask("audit-tests")
+    app.config.update(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+
+    audit_db.init_app(app)
+
+    @app.before_request
+    def _inject_user():
+        if not getattr(g, "user", None):
+            g.user = SimpleNamespace(
+                id=7,
+                email="auto@example.com",
+                username="auto-admin",
+                is_admin=True,
+            )
+
+    bind_auto_audit(app)
+
+    with app.app_context():
+        audit_db.drop_all()
+        audit_db.create_all()
+
+    try:
+        yield app
+    finally:
+        with app.app_context():
+            audit_db.session.remove()
+            audit_db.drop_all()
+
+
+@pytest.fixture
+def audit_client(audit_app):
+    with audit_app.test_client() as client:
+        yield client
+
+
+def test_log_action_persists_record(audit_app, audit_client):
+    @audit_app.route("/manual-log", methods=["POST"], endpoint="manual_audit_test")
+    def _manual_audit_route():
+        user = SimpleNamespace(id=42, email="manual@example.com", username="manual")
+        log_action(user=user, action="manual_test_action", details="manual detail message")
+        return jsonify({"ok": True})
+
+    response = audit_client.post(
+        "/manual-log",
+        json={"trigger": True},
+        environ_overrides={"REMOTE_ADDR": "203.0.113.5"},
+    )
+    assert response.status_code == 200
+
+    with audit_app.app_context():
+        entry = AuditLog.query.filter_by(action="manual_test_action").one()
+        assert entry.username == "manual@example.com"
+        assert entry.details == "manual detail message"
+        assert entry.ip_address == "203.0.113.5"
+
+
+def test_auto_admin_audit_records_mutations(audit_app, audit_client):
+    @audit_app.route(
+        "/api/admin/__audit_auto",
+        methods=["POST"],
+        endpoint="audit_auto_test_endpoint",
+    )
+    def _audit_target():
+        payload = request.get_json(silent=True) or {}
+        return jsonify({"ok": True, "payload": payload})
+
+    with audit_app.app_context():
+        initial = AuditLog.query.count()
+
+    response = audit_client.post(
+        "/api/admin/__audit_auto",
+        json={"flag": "value", "token": "should-hide"},
+    )
+
+    assert response.status_code == 200
+
+    with audit_app.app_context():
+        records = AuditLog.query.order_by(AuditLog.id.asc()).all()
+        assert len(records) == initial + 1
+        entry = records[-1]
+
+    assert entry.action.startswith("admin_auto:POST")
+    assert entry.username in {"auto-admin", "auto@example.com"}
+    assert entry.details is not None
+    assert '"path": "/api/admin/__audit_auto"' in entry.details
+    # Sensitive fields should be redacted
+    assert "should-hide" not in entry.details

--- a/backend/utils/audit.py
+++ b/backend/utils/audit.py
@@ -1,9 +1,13 @@
+import json
 import os
 import smtplib
+from collections.abc import Mapping, Sequence
 from email.mime.text import MIMEText
+from types import SimpleNamespace
+from typing import Any
 
 import requests
-from flask import request
+from flask import g, has_request_context, request
 
 from backend.db import db
 from backend.db.models import AuditLog
@@ -18,6 +22,170 @@ CRITICAL_ACTIONS = [
     "admin_login",
     "critical_error",
 ]
+
+_ADMIN_MUTATING_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+_ADMIN_PATH_PREFIXES: tuple[str, ...] = ("/api/admin", "/admin")
+_SENSITIVE_KEYS = {
+    "password",
+    "pass",
+    "pwd",
+    "token",
+    "secret",
+    "authorization",
+    "api_key",
+    "apikey",
+    "access_token",
+}
+
+
+def _serialize_details(details: Any) -> str | None:
+    if details is None:
+        return None
+    if isinstance(details, str):
+        return details
+    if isinstance(details, bytes):
+        try:
+            return details.decode("utf-8")
+        except Exception:
+            return details.decode("latin1", errors="ignore")
+    try:
+        return json.dumps(details, default=str, sort_keys=True)
+    except Exception:
+        return str(details)
+
+
+def _sanitize_payload(payload: Any) -> Any:
+    if isinstance(payload, Mapping):
+        sanitized: dict[str, Any] = {}
+        for key, value in payload.items():
+            lowered = key.lower()
+            if lowered in _SENSITIVE_KEYS:
+                sanitized[key] = "[REDACTED]"
+            else:
+                sanitized[key] = _sanitize_payload(value)
+        return sanitized
+    if isinstance(payload, (list, tuple, set)):
+        return [
+            _sanitize_payload(item) for item in (payload if isinstance(payload, Sequence) else list(payload))
+        ]
+    return payload
+
+
+def _gather_request_details(req, resp, extra: Any = None) -> dict[str, Any]:
+    details: dict[str, Any] = {}
+    if not req:
+        if isinstance(extra, Mapping):
+            return dict(extra)
+        if extra is not None:
+            return {"extra": extra}
+        return details
+
+    try:
+        details["method"] = req.method
+    except Exception:
+        pass
+
+    path = getattr(req, "path", None)
+    if path:
+        details["path"] = path
+
+    endpoint = getattr(req, "endpoint", None)
+    if endpoint:
+        details["endpoint"] = endpoint
+
+    if getattr(resp, "status_code", None) is not None:
+        try:
+            details["status_code"] = int(resp.status_code)
+        except Exception:
+            details["status_code"] = resp.status_code
+
+    query = getattr(req, "query_string", b"")
+    if query:
+        try:
+            details["query_string"] = query.decode("utf-8", errors="ignore")
+        except Exception:
+            details["query_string"] = str(query)
+
+    forwarded = req.headers.get("X-Forwarded-For") if hasattr(req, "headers") else None
+    remote_addr = forwarded or getattr(req, "remote_addr", None)
+    if remote_addr:
+        details["ip"] = remote_addr
+
+    user_agent = None
+    if hasattr(req, "headers"):
+        user_agent = req.headers.get("User-Agent")
+    if user_agent:
+        details["user_agent"] = user_agent[:256]
+
+    payload = None
+    try:
+        if getattr(req, "is_json", False):
+            payload = req.get_json(silent=True)
+    except Exception:
+        payload = None
+
+    if payload is None:
+        try:
+            form = getattr(req, "form", None)
+            if form:
+                payload = {key: form.getlist(key) for key in form}
+        except Exception:
+            payload = None
+
+    if payload:
+        details["payload"] = _sanitize_payload(payload)
+
+    if extra is None:
+        return details
+
+    if isinstance(extra, Mapping):
+        merged = dict(details)
+        merged.update(extra)
+        return merged
+
+    details["extra"] = extra
+    return details
+
+
+def _resolve_user(explicit: Any = None) -> Any:
+    if explicit is not None:
+        return explicit
+    if not has_request_context():
+        return None
+    try:
+        for attr in ("user", "current_user"):
+            candidate = getattr(g, attr, None)
+            if candidate:
+                return candidate
+    except RuntimeError:
+        return None
+    candidate = getattr(request, "current_user", None)
+    if candidate:
+        return candidate
+    return None
+
+
+def _derive_action_name(req) -> str:
+    if not req:
+        return "admin_auto"
+    method = getattr(req, "method", "").upper() or "REQUEST"
+    endpoint = getattr(req, "endpoint", None)
+    if endpoint:
+        return f"admin_auto:{method}:{endpoint}"
+    path = getattr(req, "path", None)
+    if path:
+        return f"admin_auto:{method} {path}"
+    return f"admin_auto:{method}"
+
+
+def _should_auto_audit(req, prefixes: tuple[str, ...]) -> bool:
+    if not req:
+        return False
+    method = getattr(req, "method", "").upper()
+    if method not in _ADMIN_MUTATING_METHODS:
+        return False
+    path = getattr(req, "path", "") or ""
+    return any(path.startswith(prefix) for prefix in prefixes)
 
 
 def log_action(user=None, action: str = "", details=None) -> None:
@@ -64,3 +232,97 @@ def log_action(user=None, action: str = "", details=None) -> None:
                     server.send_message(mail)
             except Exception:
                 pass
+
+
+def log_admin_mutation(
+    *,
+    user: Any = None,
+    action: str | None = None,
+    req=None,
+    resp=None,
+    details: Any = None,
+) -> None:
+    """Log an administrative mutation while preserving legacy behaviour."""
+
+    resolved_user = _resolve_user(user)
+    if resolved_user is None:
+        return
+
+    request_obj = req
+    if request_obj is None and has_request_context():
+        request_obj = request
+
+    user_for_logging = resolved_user
+    raw_user_id = getattr(resolved_user, "id", None)
+    if isinstance(raw_user_id, str):
+        try:
+            coerced = int(raw_user_id)
+        except (TypeError, ValueError):
+            coerced = None
+        user_for_logging = SimpleNamespace(
+            id=coerced,
+            email=getattr(resolved_user, "email", None),
+            username=getattr(resolved_user, "username", None),
+        )
+    elif raw_user_id is not None and not isinstance(raw_user_id, int):
+        try:
+            coerced = int(raw_user_id)
+        except (TypeError, ValueError):
+            coerced = None
+        user_for_logging = SimpleNamespace(
+            id=coerced,
+            email=getattr(resolved_user, "email", None),
+            username=getattr(resolved_user, "username", None),
+        )
+
+    derived_action = action or _derive_action_name(request_obj)
+    detail_payload: Any
+    if request_obj is not None:
+        detail_payload = _gather_request_details(request_obj, resp, details)
+    else:
+        detail_payload = details
+
+    serialized = _serialize_details(detail_payload)
+    log_action(user_for_logging, derived_action, serialized)
+
+
+def bind_auto_audit(app) -> None:
+    """Attach an after-request hook that automatically audits admin mutations."""
+
+    if getattr(app, "_auto_admin_audit_bound", False):
+        return
+
+    app.config.setdefault("ENABLE_ADMIN_AUTO_AUDIT", True)
+    raw_prefixes = app.config.get("ADMIN_AUDIT_PATH_PREFIXES")
+    if raw_prefixes:
+        if isinstance(raw_prefixes, str):
+            prefixes = tuple(
+                segment.strip() for segment in raw_prefixes.split(",") if segment.strip()
+            )
+        else:
+            prefixes = tuple(raw_prefixes)
+    else:
+        prefixes = _ADMIN_PATH_PREFIXES
+
+    @app.after_request
+    def _auto_admin_audit(response):
+        if not app.config.get("ENABLE_ADMIN_AUTO_AUDIT", True):
+            return response
+        if not has_request_context():
+            return response
+        try:
+            req = request
+            if not _should_auto_audit(req, prefixes):
+                return response
+            user = _resolve_user()
+            if user is None:
+                return response
+            log_admin_mutation(user=user, req=req, resp=response)
+        except Exception:
+            try:
+                app.logger.debug("Auto audit hook suppressed an exception", exc_info=True)
+            except Exception:
+                pass
+        return response
+
+    app._auto_admin_audit_bound = True


### PR DESCRIPTION
## Summary
- extend the audit helpers to serialise request context and add a reusable log_admin_mutation wrapper
- bind an after-request hook that auto-logs admin mutations during app setup
- add targeted tests covering manual log_action usage and automatic auditing via the new hook

## Testing
- pytest backend/tests/test_audit_logging.py


------
https://chatgpt.com/codex/tasks/task_e_68ce95bf31e8832fbbe13b9793a7aef7